### PR TITLE
fix signing configs. Use debug.keystore for signing 'debug' build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -88,10 +88,10 @@ android {
     }
     signingConfigs {
         debug {
-            storeFile file('realesEmojisushi.keystore')
-            storePassword 'vgyBHUnjiMKO'
-            keyAlias 'alias'
-            keyPassword 'vgyBHUnjiMKO'
+            storeFile file('debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
         }
         release {
                 storeFile file('realesEmojisushi.keystore')


### PR DESCRIPTION
No need to sign debug build with release key